### PR TITLE
Add sign-out button

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,14 +11,25 @@
 <link href="https://fonts.googleapis.com/css?family=Raleway" rel="stylesheet">
 <link rel="stylesheet" href="css/style.css"> 
 <script src="https://apis.google.com/js/platform.js" async defer></script>
-<script src="https://accounts.google.com/gsi/client" async></script>
-<script>
+  <script src="https://accounts.google.com/gsi/client" async></script>
+  <script>
 function onSignIn(googleUser) {
   var profile = googleUser.getBasicProfile();
   console.log('ID: ' + profile.getId()); // Do not send to your backend! Use an ID token instead.
   console.log('Name: ' + profile.getName());
   console.log('Image URL: ' + profile.getImageUrl());
   console.log('Email: ' + profile.getEmail()); // This is null if the 'email' scope is not present.
+  document.getElementById('signOutBtn').style.display = 'inline-block';
+}
+
+function signOut() {
+  var auth2 = gapi.auth2.getAuthInstance();
+  if (auth2) {
+    auth2.signOut().then(function () {
+      console.log('User signed out.');
+      document.getElementById('signOutBtn').style.display = 'none';
+    });
+  }
 }
 </script>
 </head>
@@ -30,6 +41,7 @@ function onSignIn(googleUser) {
     <p><input placeholder="First name..." oninput="this.className = ''" name="fname"></p>
     <p><input placeholder="Last name..." oninput="this.className = ''" name="lname"></p>
     <div class="g-signin2" data-onsuccess="onSignIn"></div>
+    <button type="button" id="signOutBtn" onclick="signOut()" style="display:none;">Sign out</button>
   </div>
   <div class="tab">Contact Info:
     <p><input placeholder="E-mail..." oninput="this.className = ''" name="email"></p>


### PR DESCRIPTION
## Summary
- add Google Sign Out button in the registration form
- implement `signOut()` handler that hides the button after sign-out
- show the sign-out button when sign-in completes

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b09d89e2483268aa97f73b0dde744