### PR TITLE
Implement localStorage caching for form data

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -92,3 +92,7 @@ button:hover {
 .step.finish {
   background-color: #04AA6D;
 }
+
+#summary {
+  white-space: pre-line;
+}

--- a/js/stepform.js
+++ b/js/stepform.js
@@ -1,5 +1,17 @@
 var currentTab = 0; // Current tab is set to be the first tab (0)
-showTab(currentTab); // Display the current tab
+
+document.addEventListener("DOMContentLoaded", function () {
+  const inputs = document.querySelectorAll("#regForm input");
+  inputs.forEach((inp) => {
+    const cached = localStorage.getItem(inp.name);
+    if (cached) inp.value = cached;
+    inp.addEventListener("input", () => {
+      localStorage.setItem(inp.name, inp.value);
+    });
+  });
+  showTab(currentTab); // Display the current tab
+  compileSummary();
+});
 
 function showTab(n) {
   // This function will display the specified tab of the form...
@@ -93,9 +105,13 @@ function compileSummary() {
   const yyyy = document.querySelector("input[name='yyyy']").value;
   const uname = document.querySelector("input[name='uname']").value;
 
-  const summary = `Name: ${fname} ${lname}\nEmail: ${email}\nPhone: ${phone}\nBirthday: ${dd}/${mm}/${yyyy}\nUsername: ${uname}`;
-  const summaryEl = document.getElementById('summary');
-  if (summaryEl) summaryEl.innerText = summary;
+  const summary =
+    `Name:\n${fname} ${lname}` +
+    `\nContact Info:\n${email}\n${phone}` +
+    `\nBirthday:\n${dd}/${mm}/${yyyy}` +
+    `\nUsername:\n${uname}`;
+  const summaryEl = document.getElementById("summary");
+  if (summaryEl) summaryEl.textContent = summary;
 }
 
 // ----------------------


### PR DESCRIPTION
## Summary
- keep summary text whitespace with `pre-line`
- cache form input values in localStorage and load them on page load
- format the summary text for readability

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b22ad54d88326a18cd0c4df223041