### PR TITLE
Disable text highlight on page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,6 +5,9 @@
 
 body {
   background-color: #f1f1f1;
+  user-select: none;
+  -webkit-user-select: none; /* Safari */
+  -ms-user-select: none; /* IE 10 and IE 11 */
 }
 
 #regForm {
@@ -26,6 +29,9 @@ input {
   font-size: 17px;
   font-family: Raleway;
   border: 1px solid #aaaaaa;
+  user-select: text;
+  -webkit-user-select: text;
+  -ms-user-select: text;
 }
 
 /* Mark input boxes that gets an error on validation: */


### PR DESCRIPTION
## Summary
- disable text selection across the page to prevent unwanted highlighting
- allow text selection only inside form inputs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b23a9e3dc8326a284a7131e5f9dc0