### PR TITLE
Disable swipe on drag inside inputs

### DIFF
--- a/js/stepform.js
+++ b/js/stepform.js
@@ -127,6 +127,13 @@ const swipeTarget = document.getElementById("regForm");
 
 if (swipeTarget) {
   swipeTarget.addEventListener("pointerdown", function (e) {
+    // Don't start a swipe when interacting with form inputs
+    if (e.target.closest("input, textarea")) {
+      dragging = false;
+      startX = null;
+      startY = null;
+      return;
+    }
     startX = e.clientX;
     startY = e.clientY;
     dragging = true;


### PR DESCRIPTION
## Summary
- prevent swipe navigation when starting drag inside input boxes

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b294ade4c83269e1507e196701426